### PR TITLE
fix: fix module mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-preset-es2015": "^6.24.1",
     "codecov": "^2.3.1",
     "commitizen": "^2.10.1",
+    "create-require": "^1.1.1",
     "cz-conventional-changelog": "^2.1.0",
     "eslint": "^3.12.0 || ^4 || ^5 || ^6 || ^7 || ^8",
     "eslint-plugin-json": "^3.1.0",

--- a/test/lib/rule-finder.js
+++ b/test/lib/rule-finder.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const module = require('module');
+const createRequire = require('create-require');
 const assert = require('assert');
 const proxyquire = require('proxyquire');
 
@@ -16,7 +16,7 @@ const supportsScopedPlugins = semver.satisfies(eslintPkg.version, '>= 5');
 // path, but it is simple, and works. Otherwise, we just call the original
 // `resolve` from the stock module.
 const mockResolve = (plugins, relative, name) => (
-  plugins.includes(name) ? name : module.createRequire(relative).resolve(name)
+  plugins.includes(name) ? name : createRequire(relative).resolve(name)
 );
 
 const getRuleFinder = proxyquire('../../src/lib/rule-finder', {


### PR DESCRIPTION
* Use `create-require` polyfill to fix `Module.createRequire` for Node.js <= 12.2.0.
* Use the mocked `require` to handle invocation of `require` created by `createRequire`.

eslint 7 - 8 fails for the [promises](https://github.com/sarbbottam/eslint-find-rules/pull/337#discussion_r742695726), not for the mocks.