### PR TITLE
feat: migrate cli scripts and their test cases

### DIFF
--- a/src/bin/diff.js
+++ b/src/bin/diff.js
@@ -17,7 +17,7 @@ const getSortedRules = require('../lib/sort-rules');
 const flattenRulesDiff = require('../lib/flatten-rules-diff');
 const stringifyRuleConfig = require('../lib/stringify-rule-config');
 
-module.exports = (async function() {
+(async function () {
 
 const files = [argv._[0], argv._[1]];
 const collectedRules = await Promise.all(getFilesToCompare(files).map(compareConfigs));
@@ -97,6 +97,8 @@ function rulesDifference(a, b) {
     )
   );
 }
+
+process.exit(0);
 
 })().catch((e) => {
   console.error(e);

--- a/src/bin/diff.js
+++ b/src/bin/diff.js
@@ -100,7 +100,7 @@ function rulesDifference(a, b) {
 
 process.exit(0);
 
-})().catch((e) => {
+})().catch(/* istanbul ignore next */(e) => {
   console.error(e);
   process.exit(1);
 });

--- a/src/bin/diff.js
+++ b/src/bin/diff.js
@@ -17,8 +17,10 @@ const getSortedRules = require('../lib/sort-rules');
 const flattenRulesDiff = require('../lib/flatten-rules-diff');
 const stringifyRuleConfig = require('../lib/stringify-rule-config');
 
+module.exports = (async function() {
+
 const files = [argv._[0], argv._[1]];
-const collectedRules = getFilesToCompare(files).map(compareConfigs);
+const collectedRules = await Promise.all(getFilesToCompare(files).map(compareConfigs));
 
 const rulesCount = collectedRules.reduce(
   (prev, curr) => {
@@ -66,13 +68,13 @@ function getFilesToCompare(allFiles) {
   return filesToCompare;
 }
 
-function compareConfigs(currentFiles) {
+async function compareConfigs(currentFiles) {
   return {
     config1: path.basename(currentFiles[0]),
     config2: path.basename(currentFiles[1]),
     rules: rulesDifference(
-      getRuleFinder(currentFiles[0]),
-      getRuleFinder(currentFiles[1])
+      await getRuleFinder(currentFiles[0]),
+      await getRuleFinder(currentFiles[1])
     )
   };
 }
@@ -94,3 +96,8 @@ function rulesDifference(a, b) {
     )
   );
 }
+
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/bin/diff.js
+++ b/src/bin/diff.js
@@ -69,12 +69,13 @@ function getFilesToCompare(allFiles) {
 }
 
 async function compareConfigs(currentFiles) {
+  const ruleFinders = await Promise.all(currentFiles.slice(0, 2).map(getRuleFinder));
   return {
     config1: path.basename(currentFiles[0]),
     config2: path.basename(currentFiles[1]),
     rules: rulesDifference(
-      await getRuleFinder(currentFiles[0]),
-      await getRuleFinder(currentFiles[1])
+      ruleFinders[0],
+      ruleFinders[1]
     )
   };
 }

--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -33,13 +33,15 @@ const getRuleURI = require('eslint-rule-documentation');
 const getRuleFinder = require('../lib/rule-finder');
 const cli = require('../lib/cli-util');
 
+module.exports = (async function() {
+
 const specifiedFile = argv._[0];
 const finderOptions = {
   omitCore: !argv.core,
   includeDeprecated: argv.include === 'deprecated',
   ext: argv.ext
 };
-const ruleFinder = getRuleFinder(specifiedFile, finderOptions);
+const ruleFinder = await getRuleFinder(specifiedFile, finderOptions);
 const errorOut = argv.error && !argv.n;
 let processExitCode = 0;
 
@@ -76,3 +78,8 @@ if (!argv.c && !argv.p && !argv.a && !argv.u && !argv.d) {
   cli.write();
 }
 process.exit(processExitCode);
+
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -79,7 +79,7 @@ if (!argv.c && !argv.p && !argv.a && !argv.u && !argv.d) {
 }
 process.exit(processExitCode);
 
-})().catch((e) => {
+})().catch(/* istanbul ignore next */(e) => {
   console.error(e);
   process.exit(1);
 });

--- a/src/bin/find.js
+++ b/src/bin/find.js
@@ -33,7 +33,7 @@ const getRuleURI = require('eslint-rule-documentation');
 const getRuleFinder = require('../lib/rule-finder');
 const cli = require('../lib/cli-util');
 
-module.exports = (async function() {
+(async function () {
 
 const specifiedFile = argv._[0];
 const finderOptions = {

--- a/test/bin/diff.js
+++ b/test/bin/diff.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 const consoleLog = console.log; // eslint-disable-line no-console
 
 const stub = {
-  '../lib/rule-finder'() {
+  async '../lib/rule-finder'() {
     return {
       getCurrentRules() {}, // Noop
       getCurrentRulesDetailed() {} // Noop
@@ -32,10 +32,10 @@ describe('diff', () => {
     delete require.cache[require.resolve('yargs')];
   });
 
-  it('logs diff', () => {
+  it('logs diff', async () => {
     process.argv[2] = './foo';
     process.argv[3] = './bar';
-    proxyquire('../../src/bin/diff', stub);
+    await proxyquire('../../src/bin/diff', stub);
     assert.ok(
       console.log.calledWith( // eslint-disable-line no-console
         sinon.match(
@@ -45,11 +45,11 @@ describe('diff', () => {
     );
   });
 
-  it('logs diff verbosely', () => {
+  it('logs diff verbosely', async () => {
     process.argv[2] = '--verbose';
     process.argv[3] = './foo';
     process.argv[4] = './bar';
-    proxyquire('../../src/bin/diff', stub);
+    await proxyquire('../../src/bin/diff', stub);
     assert.ok(
       console.log.calledWith( // eslint-disable-line no-console
         sinon.match(

--- a/test/bin/diff.js
+++ b/test/bin/diff.js
@@ -27,13 +27,9 @@ describe('diff', () => {
         consoleLog(...args);
       }
     });
-    let exitResolve;
     exitStatus = new Promise(resolve => {
-      exitResolve = resolve;
+      process.exit = resolve;
     });
-    process.exit = (status) => {
-      exitResolve(status);
-    };
   });
 
   afterEach(() => {

--- a/test/bin/find.js
+++ b/test/bin/find.js
@@ -34,9 +34,12 @@ describe('bin', () => {
       }
       consoleLog(...args);
     };
-    exitStatus = null;
+    let exitResolve;
+    exitStatus = new Promise(resolve => {
+      exitResolve = resolve;
+    });
     process.exit = status => {
-      exitStatus = status;
+      exitResolve(status);
     };
     process.argv = process.argv.slice(0, 2);
   });
@@ -59,117 +62,120 @@ describe('bin', () => {
       }
       consoleLog(...args);
     };
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.equal(callCount, 3); // eslint-disable-line no-console
   });
 
   it('option -c|--current', async () => {
     process.argv[2] = '-c';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getCurrentRules.called);
-    assert.equal(exitStatus, 0);
   });
 
   it('option -p|--plugin', async () => {
     process.argv[2] = '-p';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getPluginRules.called);
-    assert.equal(exitStatus, 0);
   });
 
   it('option -a|--all-available', async () => {
     process.argv[2] = '-a';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getAllAvailableRules.called);
     process.argv[2] = '--all-available';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getAllAvailableRules.called);
-    assert.equal(exitStatus, 0);
   });
 
   it('option -a along with --ext', async () => {
     process.argv[2] = '-a';
     process.argv[3] = '--ext .json';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getAllAvailableRules.called);
-    assert.equal(exitStatus, 0);
   });
 
   it('option -a along with multi --ext', async () => {
     process.argv[2] = '-a';
     process.argv[3] = '--ext .js';
     process.argv[4] = '--ext .json';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getAllAvailableRules.called);
-    assert.equal(exitStatus, 0);
   });
 
   it('option -u|--unused', async () => {
     process.argv[2] = '-u';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 1);
     assert.ok(getUnusedRules.called);
-    assert.equal(exitStatus, 1);
   });
 
   it('options -u|--unused and no unused rules found', async () => {
     getUnusedRules.returns([]);
     process.argv[2] = '-u';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getUnusedRules.called);
-    assert.equal(exitStatus, 0);
   });
 
   it('option -u|--unused along with -n', async () => {
     process.argv[2] = '-u';
     process.argv[3] = '-n';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getUnusedRules.called);
-    assert.equal(exitStatus, 0);
   });
 
   it('option -u|--unused along with --no-error', async () => {
     process.argv[2] = '-u';
     process.argv[3] = '--no-error';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getUnusedRules.called);
-    assert.equal(exitStatus, 0);
   });
 
   it('option -d|--deprecated', async () => {
     process.argv[2] = '-d';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 1);
     assert.ok(getDeprecatedRules.called);
-    assert.equal(exitStatus, 1);
   });
 
   it('options -d|--deprecated and no deprecated rules found', async () => {
     getDeprecatedRules.returns([]);
     process.argv[2] = '-d';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getDeprecatedRules.called);
-    assert.equal(exitStatus, 0);
   });
 
   it('option -d|--deprecated along with -n', async () => {
     process.argv[2] = '-d';
     process.argv[3] = '-n';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getDeprecatedRules.called);
-    assert.equal(exitStatus, 0);
   });
 
   it('option -d|--deprecated along with --no-error', async () => {
     process.argv[2] = '-d';
     process.argv[3] = '--no-error';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getDeprecatedRules.called);
-    assert.equal(exitStatus, 0);
   });
 
   it('logs verbosely', async () => {
     process.argv[2] = '-c';
     process.argv[3] = '-v';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
     assert.ok(getCurrentRules.called);
   });
 
@@ -185,7 +191,8 @@ describe('bin', () => {
       }
     };
     process.argv[2] = '-c';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
   });
 
   it('does not log core rules with --no-core', async () => {
@@ -201,7 +208,8 @@ describe('bin', () => {
     };
     process.argv[2] = '-c';
     process.argv[3] = '--no-core';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
   });
 
   it('does not include deprecated rules by default', async () => {
@@ -216,7 +224,8 @@ describe('bin', () => {
       }
     };
     process.argv[2] = '-a';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
   });
 
   it('includes deprecated rules with --include deprecated', async () => {
@@ -232,7 +241,8 @@ describe('bin', () => {
     };
     process.argv[2] = '-a';
     process.argv[3] = '--include=deprecated';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
   });
 
   it('includes deprecated rules with -i deprecated', async () => {
@@ -249,6 +259,7 @@ describe('bin', () => {
     process.argv[2] = '-a';
     process.argv[3] = '-i';
     process.argv[4] = 'deprecated';
-    await proxyquire('../../src/bin/find', stub);
+    proxyquire('../../src/bin/find', stub);
+    assert.strictEqual(await exitStatus, 0);
   });
 });

--- a/test/bin/find.js
+++ b/test/bin/find.js
@@ -34,13 +34,9 @@ describe('bin', () => {
       }
       consoleLog(...args);
     };
-    let exitResolve;
     exitStatus = new Promise(resolve => {
-      exitResolve = resolve;
+      process.exit = resolve;
     });
-    process.exit = status => {
-      exitResolve(status);
-    };
     process.argv = process.argv.slice(0, 2);
   });
 

--- a/test/bin/find.js
+++ b/test/bin/find.js
@@ -17,7 +17,7 @@ let exitStatus;
 describe('bin', () => {
   beforeEach(() => {
     stub = {
-      '../lib/rule-finder'() {
+      async '../lib/rule-finder'() {
         return {
           getCurrentRules,
           getPluginRules,
@@ -48,7 +48,7 @@ describe('bin', () => {
     delete require.cache[require.resolve('yargs')];
   });
 
-  it('no option', () => {
+  it('no option', async () => {
     let callCount = 0;
     console.log = (...args) => { // eslint-disable-line no-console
       callCount += 1;
@@ -59,123 +59,123 @@ describe('bin', () => {
       }
       consoleLog(...args);
     };
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.equal(callCount, 3); // eslint-disable-line no-console
   });
 
-  it('option -c|--current', () => {
+  it('option -c|--current', async () => {
     process.argv[2] = '-c';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getCurrentRules.called);
     assert.equal(exitStatus, 0);
   });
 
-  it('option -p|--plugin', () => {
+  it('option -p|--plugin', async () => {
     process.argv[2] = '-p';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getPluginRules.called);
     assert.equal(exitStatus, 0);
   });
 
-  it('option -a|--all-available', () => {
+  it('option -a|--all-available', async () => {
     process.argv[2] = '-a';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getAllAvailableRules.called);
     process.argv[2] = '--all-available';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getAllAvailableRules.called);
     assert.equal(exitStatus, 0);
   });
 
-  it('option -a along with --ext', () => {
+  it('option -a along with --ext', async () => {
     process.argv[2] = '-a';
     process.argv[3] = '--ext .json';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getAllAvailableRules.called);
     assert.equal(exitStatus, 0);
   });
 
-  it('option -a along with multi --ext', () => {
+  it('option -a along with multi --ext', async () => {
     process.argv[2] = '-a';
     process.argv[3] = '--ext .js';
     process.argv[4] = '--ext .json';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getAllAvailableRules.called);
     assert.equal(exitStatus, 0);
   });
 
-  it('option -u|--unused', () => {
+  it('option -u|--unused', async () => {
     process.argv[2] = '-u';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getUnusedRules.called);
     assert.equal(exitStatus, 1);
   });
 
-  it('options -u|--unused and no unused rules found', () => {
+  it('options -u|--unused and no unused rules found', async () => {
     getUnusedRules.returns([]);
     process.argv[2] = '-u';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getUnusedRules.called);
     assert.equal(exitStatus, 0);
   });
 
-  it('option -u|--unused along with -n', () => {
+  it('option -u|--unused along with -n', async () => {
     process.argv[2] = '-u';
     process.argv[3] = '-n';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getUnusedRules.called);
     assert.equal(exitStatus, 0);
   });
 
-  it('option -u|--unused along with --no-error', () => {
+  it('option -u|--unused along with --no-error', async () => {
     process.argv[2] = '-u';
     process.argv[3] = '--no-error';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getUnusedRules.called);
     assert.equal(exitStatus, 0);
   });
 
-  it('option -d|--deprecated', () => {
+  it('option -d|--deprecated', async () => {
     process.argv[2] = '-d';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getDeprecatedRules.called);
     assert.equal(exitStatus, 1);
   });
 
-  it('options -d|--deprecated and no deprecated rules found', () => {
+  it('options -d|--deprecated and no deprecated rules found', async () => {
     getDeprecatedRules.returns([]);
     process.argv[2] = '-d';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getDeprecatedRules.called);
     assert.equal(exitStatus, 0);
   });
 
-  it('option -d|--deprecated along with -n', () => {
+  it('option -d|--deprecated along with -n', async () => {
     process.argv[2] = '-d';
     process.argv[3] = '-n';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getDeprecatedRules.called);
     assert.equal(exitStatus, 0);
   });
 
-  it('option -d|--deprecated along with --no-error', () => {
+  it('option -d|--deprecated along with --no-error', async () => {
     process.argv[2] = '-d';
     process.argv[3] = '--no-error';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getDeprecatedRules.called);
     assert.equal(exitStatus, 0);
   });
 
-  it('logs verbosely', () => {
+  it('logs verbosely', async () => {
     process.argv[2] = '-c';
     process.argv[3] = '-v';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
     assert.ok(getCurrentRules.called);
   });
 
-  it('logs core rules', () => {
+  it('logs core rules', async () => {
     stub = {
-      '../lib/rule-finder'(specifiedFile, options) {
+      async '../lib/rule-finder'(specifiedFile, options) {
         return {
           getCurrentRules() {
             assert(!options.omitCore);
@@ -185,12 +185,12 @@ describe('bin', () => {
       }
     };
     process.argv[2] = '-c';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
   });
 
-  it('does not log core rules with --no-core', () => {
+  it('does not log core rules with --no-core', async () => {
     stub = {
-      '../lib/rule-finder'(specifiedFile, options) {
+      async '../lib/rule-finder'(specifiedFile, options) {
         return {
           getCurrentRules() {
             assert(options.omitCore);
@@ -201,12 +201,12 @@ describe('bin', () => {
     };
     process.argv[2] = '-c';
     process.argv[3] = '--no-core';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
   });
 
-  it('does not include deprecated rules by default', () => {
+  it('does not include deprecated rules by default', async () => {
     stub = {
-      '../lib/rule-finder'(specifiedFile, options) {
+      async '../lib/rule-finder'(specifiedFile, options) {
         return {
           getAllAvailableRules() {
             assert(!options.includeDeprecated);
@@ -216,12 +216,12 @@ describe('bin', () => {
       }
     };
     process.argv[2] = '-a';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
   });
 
-  it('includes deprecated rules with --include deprecated', () => {
+  it('includes deprecated rules with --include deprecated', async () => {
     stub = {
-      '../lib/rule-finder'(specifiedFile, options) {
+      async '../lib/rule-finder'(specifiedFile, options) {
         return {
           getAllAvailableRules() {
             assert(options.includeDeprecated);
@@ -232,12 +232,12 @@ describe('bin', () => {
     };
     process.argv[2] = '-a';
     process.argv[3] = '--include=deprecated';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
   });
 
-  it('includes deprecated rules with -i deprecated', () => {
+  it('includes deprecated rules with -i deprecated', async () => {
     stub = {
-      '../lib/rule-finder'(specifiedFile, options) {
+      async '../lib/rule-finder'(specifiedFile, options) {
         return {
           getAllAvailableRules() {
             assert(options.includeDeprecated);
@@ -249,6 +249,6 @@ describe('bin', () => {
     process.argv[2] = '-a';
     process.argv[3] = '-i';
     process.argv[4] = 'deprecated';
-    proxyquire('../../src/bin/find', stub);
+    await proxyquire('../../src/bin/find', stub);
   });
 });


### PR DESCRIPTION
Resolve https://github.com/MichaelDeBoey/eslint-find-rules/pull/13#discussion_r744206525

This adapts the bin scripts and their test files to the asynchronous API in https://github.com/MichaelDeBoey/eslint-find-rules/pull/13.